### PR TITLE
A few fixes

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -41,16 +41,12 @@ SDL2TestApplication::SDL2TestApplication(int major, int minor)
 
 SDL2TestApplication::~SDL2TestApplication()
 {
-    std::vector<TouchPoint*>::iterator it;
-    for (it=m_touches.begin(); it != m_touches.end(); ++it) {
-        delete *it;
-    }
 }
 
 void
 SDL2TestApplication::for_each_touch(touch_point_func f, void *user_data)
 {
-    std::vector<TouchPoint*>::iterator it;
+    std::vector<TouchPoint>::iterator it;
     for (it=m_touches.begin(); it != m_touches.end(); ++it) {
         f(*it, user_data);
     }
@@ -96,8 +92,7 @@ SDL2TestApplication::run()
     initGL();
     resizeGL(w, h);
 
-    std::vector<TouchPoint*>::iterator it;
-    TouchPoint *touch;
+    std::vector<TouchPoint>::iterator it;
 
     SDL_Event event;
     int quit = 0;
@@ -111,24 +106,24 @@ SDL2TestApplication::run()
                     printf("Window event: %d (%d, %d)\n", event.window.event,
                             event.window.data1, event.window.data2);
                     break;
-                case SDL_FINGERDOWN:
-                    touch = new TouchPoint(event.tfinger.fingerId,
+                case SDL_FINGERDOWN: {
+                    TouchPoint touch(event.tfinger.fingerId,
                             event.tfinger.x, event.tfinger.y);
                     m_touches.push_back(touch);
                     onPressed(touch);
-                    printf("Finger down: (%.2f, %.2f)\n", touch->x, touch->y);
+                    printf("Finger down: (%.2f, %.2f)\n", touch.x, touch.y);
                     break;
+                }
                 case SDL_FINGERUP:
                 case SDL_FINGERMOTION:
                     for (it=m_touches.begin(); it != m_touches.end(); ++it) {
-                        touch = *it;
-                        if (touch->id == event.tfinger.fingerId) {
+                        if (it->id == event.tfinger.fingerId) {
                             if (event.type == SDL_FINGERMOTION) {
-                                touch->x = event.tfinger.x;
-                                touch->y = event.tfinger.y;
-                                printf("finger move: (%.2f, %.2f)\n", touch->x, touch->y);
+                                it->x = event.tfinger.x;
+                                it->y = event.tfinger.y;
+                                printf("finger move: (%.2f, %.2f)\n", it->x, it->y);
                             } else {
-                                printf("Finger up: (%.2f, %.2f)\n", touch->x, touch->y);
+                                printf("Finger up: (%.2f, %.2f)\n", it->x, it->y);
                                 m_touches.erase(it);
                             }
                             break;

--- a/common.cpp
+++ b/common.cpp
@@ -41,7 +41,7 @@ SDL2TestApplication::SDL2TestApplication(int major, int minor)
 
 SDL2TestApplication::~SDL2TestApplication()
 {
-    std::list<TouchPoint*>::iterator it;
+    std::vector<TouchPoint*>::iterator it;
     for (it=m_touches.begin(); it != m_touches.end(); ++it) {
         delete *it;
     }
@@ -50,7 +50,7 @@ SDL2TestApplication::~SDL2TestApplication()
 void
 SDL2TestApplication::for_each_touch(touch_point_func f, void *user_data)
 {
-    std::list<TouchPoint*>::iterator it;
+    std::vector<TouchPoint*>::iterator it;
     for (it=m_touches.begin(); it != m_touches.end(); ++it) {
         f(*it, user_data);
     }
@@ -96,7 +96,7 @@ SDL2TestApplication::run()
     initGL();
     resizeGL(w, h);
 
-    std::list<TouchPoint*>::iterator it;
+    std::vector<TouchPoint*>::iterator it;
     TouchPoint *touch;
 
     SDL_Event event;

--- a/common.h
+++ b/common.h
@@ -32,7 +32,7 @@
 #include <SDL.h>
 #include <stdio.h>
 
-#include <list>
+#include <vector>
 
 class TouchPoint {
     public:
@@ -65,7 +65,7 @@ class SDL2TestApplication {
         int m_minor;
         SDL_Window *m_window;
         SDL_GLContext m_gl_context;
-        std::list<TouchPoint*> m_touches;
+        std::vector<TouchPoint*> m_touches;
 };
 
 #endif /* SAILFISH_SDL_WAYLAND_OPENGL_TEST_H */

--- a/common.h
+++ b/common.h
@@ -43,7 +43,7 @@ class TouchPoint {
         float y;
 };
 
-typedef void (*touch_point_func)(TouchPoint *touch, void *user_data);
+typedef void (*touch_point_func)(const TouchPoint &touch, void *user_data);
 
 class SDL2TestApplication {
     public:
@@ -56,7 +56,7 @@ class SDL2TestApplication {
         virtual void resizeGL(int width, int height) = 0;
         virtual void renderGL() = 0;
 
-        virtual void onPressed(TouchPoint *touch) {}
+        virtual void onPressed(const TouchPoint &touch) {}
 
         void for_each_touch(touch_point_func f, void *user_data);
 
@@ -65,7 +65,7 @@ class SDL2TestApplication {
         int m_minor;
         SDL_Window *m_window;
         SDL_GLContext m_gl_context;
-        std::vector<TouchPoint*> m_touches;
+        std::vector<TouchPoint> m_touches;
 };
 
 #endif /* SAILFISH_SDL_WAYLAND_OPENGL_TEST_H */

--- a/sdltest.cpp
+++ b/sdltest.cpp
@@ -159,15 +159,15 @@ SDL2TestApplicationGLESv2::resizeGL(int width, int height)
 }
 
 static void
-draw_touch_point(TouchPoint *touch, void *user_data)
+draw_touch_point(const TouchPoint &touch, void *user_data)
 {
     float d = 30;
 
     float vertices[] = {
-        touch->x - d, touch->y - d,
-        touch->x + d, touch->y - d,
-        touch->x - d, touch->y + d,
-        touch->x + d, touch->y + d,
+        touch.x - d, touch.y - d,
+        touch.x + d, touch.y - d,
+        touch.x - d, touch.y + d,
+        touch.x + d, touch.y + d,
     };
 
     int vtxcoord_loc = *((int*)user_data);


### PR DESCRIPTION
This MR fixes a few issues:
- use std::vector instead of std::list because it is faster and uses less memory
- store touches as values instead of pointers

The latter fixes a memory leak. The code created touch points with new but did not free them when using .erase() (it did in the destructor). With value types memory leaks become impossible (and take less memory too).
