### PR TITLE
Port to QMake and thus fix automatic dependencies installation

### DIFF
--- a/harbour-sdltest.pro
+++ b/harbour-sdltest.pro
@@ -1,4 +1,9 @@
-TEMPLATE = aux
+TEMPLATE = app
+TARGET = harbour-sdltest
+QT =
+
+PKGCONFIG += sdl2 egl glesv1_cm glesv2 SDL2_image SDL2_ttf SDL2_mixer
+CONFIG += link_pkgconfig
 
 # Source files
 SOURCES += $$files(*.cpp)
@@ -7,10 +12,39 @@ SOURCES += $$files(*.cpp)
 HEADERS += $$files(*.h)
 
 # Application icon
-OTHER_FILES += $$files(*.desktop) $$files(*.png)
+OTHER_FILES += $$files(*.desktop)
 
 # Other data files
 OTHER_FILES += $$files(data/*)
 
 # Build system files
 OTHER_FILES += makefile $$files(rpm/*.spec)
+
+# Installation directories
+isEmpty(INSTALL_PREFIX) {
+    INSTALL_PREFIX = /usr
+}
+
+isEmpty(INSTALL_BIN_DIR) {
+    INSTALL_BIN_DIR = $$INSTALL_PREFIX/bin
+}
+
+isEmpty(INSTALL_DATA_DIR) {
+    INSTALL_DATA_DIR = $$INSTALL_PREFIX/share
+}
+
+# Data files
+data_files_install.files = data/*
+data_files_install.path = $$INSTALL_DATA_DIR/harbour-sdltest
+
+# Desktop
+desktop_entry.files = $$files(*.desktop)
+desktop_entry.path = $$INSTALL_DATA_DIR/applications
+desktop_entry.CONFIG += no_check_exist
+
+# Icon
+icon_file.files = $$files(*.png)
+icon_file.path = $$INSTALL_DATA_DIR/icons/hicolor/86x86/apps
+
+target.path = $$INSTALL_BIN_DIR
+INSTALLS += target desktop_entry icon_file data_files_install

--- a/rpm/harbour-sdltest.spec
+++ b/rpm/harbour-sdltest.spec
@@ -14,6 +14,9 @@ BuildRequires: pkgconfig(SDL2_image)
 BuildRequires: pkgconfig(SDL2_ttf)
 BuildRequires: pkgconfig(SDL2_mixer)
 
+%{!?qtc_qmake5:%define qtc_qmake5 %{qmake5}}
+%{!?qtc_make:%define qtc_make make}
+
 %description
 Short description of my SailfishOS Application
 
@@ -23,8 +26,9 @@ Short description of my SailfishOS Application
 #%configure
 
 %build
-# Command used to compile the application
-make
+
+%{qtc_qmake5}
+%{qtc_make}
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
It seems that ATM automatic dependencies installation (in Sailfish OS SDK) works only if there is qtc_make macro definition in the spec file.